### PR TITLE
Switch to Prometheus2

### DIFF
--- a/ops/monitor-http-probe.yml
+++ b/ops/monitor-http-probe.yml
@@ -19,7 +19,7 @@
 
 # Prometheus Scrape Config
 - type: replace
-  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
   value:
     job_name: blackbox
     metrics_path: /probe
@@ -48,7 +48,7 @@
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/probe_alerts/*.alerts
 
 # Grafana Dashboards

--- a/ops/prometheus-config-ops.yml
+++ b/ops/prometheus-config-ops.yml
@@ -3,7 +3,7 @@
   path: /instance_groups/name=prometheus/jobs/name=cloudfoundry_alerts?/release
   value: prometheus
 - type: replace
-  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/cloudfoundry_alerts/*.alerts
 # cf Grafana Dashboards
 - type: replace
@@ -17,7 +17,7 @@
   path: /instance_groups/name=prometheus/jobs/name=bosh_alerts?/release
   value: prometheus
 - type: replace
-  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/bosh_alerts/*.alerts
 # Bosh Grafana Dashboards
 - type: replace
@@ -29,7 +29,7 @@
 
 # Prometheus Scrape Config
 - type: replace
-  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
   value:
     job_name: bosh
     scrape_interval: 2m
@@ -39,7 +39,7 @@
         - localhost:9190
 # Service Discovery
 - type: replace
-  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
   value:
     job_name: bosh_tsdb
     file_sd_configs:
@@ -56,7 +56,7 @@
         target_label: __address__
         replacement: "${1}:9194"
 - type: replace
-  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
   value:
     job_name: cf
     scrape_interval: 4m
@@ -75,7 +75,7 @@
         target_label: __address__
         replacement: "${1}:9193"
 - type: replace
-  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
   value:
     job_name: firehose
     scrape_interval: 1m

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -35,7 +35,7 @@ instance_groups:
     networks:
       - name: default
     jobs:
-      - name: prometheus
+      - name: prometheus2
         release: prometheus
         properties:
           prometheus:
@@ -173,11 +173,11 @@ stemcells:
     version: latest
 
 releases:
-- name: postgres
-  version: "23"
-  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=23
-  sha1: 4b5265bfd5f92cf14335a75658658a0db0bca927
-- name: prometheus
-  version: 21.0.0
-  url: https://github.com/bosh-prometheus/prometheus-boshrelease/releases/download/v21.0.0/prometheus-21.0.0.tgz
-  sha1: 606757c5cd5192e875768da3c581970d3146328c
+- name: "postgres"
+  version: "28"
+  url: "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=28"
+  sha1: "c1fcec62cb9d2e95e3b191e3c91d238e2b9d23fa"
+- name: "prometheus"
+  version: "v22.0.1"
+  url: "https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=v22.0.1"
+  sha1: "aedaad2aa7ca56a2d2a96fe197706f29b95f8bd0"


### PR DESCRIPTION
Switch to the prometheus2 stream for newer versions of everything. This also allows us to set the prometheus job parameter web.external_url in order to avoid having bosh hostnames in the URLs that are shown.