### PR TITLE
Use names instead of number for PCF

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is recommended to create a bosh_exporter UAA client with "refresh_token" gran
 ```
 Without refresh_token grant type, a UAA client may expire and therefore cause the outage of the monitoring.
 
-You may add an ops file for creating bosh_exporter UAA account.  A sample ops file (add-bosh-exporter-uaa-clients.yml) can be found at the ops directory.  If the bosh director is created by BBL, add a "create-director-override.sh" file in the same directory as for the default "create-director.sh" file to add the ops file.
+You may add an ops file for creating bosh_exporter UAA account.  A sample ops file (add-bosh-exporter-uaa-clients.yml) can be found at the ops directory.  If the bosh director is created by BBL, add a "create-director-override.sh" file in the same directory as for the default "create-director.sh" file to add the ops file. Note: This ops file is for the bosh director, NOT for prometheus.
 
 ### Step 2:
 Run ```./create-exporter-uaa.sh``` to generate the UAA clients for cf and firehose exporters for the PCF foundations to be monitored.  Access to the cloud controller and doppler endpoints are the only requirements on the PCF side.

--- a/add-pcf.sh
+++ b/add-pcf.sh
@@ -44,12 +44,12 @@ for (( c=1; c<=$envNum; c++ )) do
   #validateStringInput $firehoseExporterSecret
 
   cat >> ./${PARAM_FILE} <<EOL
-pcf${index}_metrics_environment: $pcfName
-pcf${index}_metron_deployment_name: cf
-pcf${index}_system_domain: $sysDomain
-pcf${index}_traffic_controller_external_port: 443
-pcf${index}_uaa_clients_cf_exporter_secret: $cfExporterSecret
-pcf${index}_uaa_clients_firehose_exporter_secret: $firehoseExporterSecret
+${pcfName}_metrics_environment: $pcfName
+${pcfName}_metron_deployment_name: cf
+${pcfName}_system_domain: $sysDomain
+${pcfName}_traffic_controller_external_port: 443
+${pcfName}_uaa_clients_cf_exporter_secret: $cfExporterSecret
+${pcfName}_uaa_clients_firehose_exporter_secret: $firehoseExporterSecret
 EOL
 
     cat >> ./ops/${EXPORTER_OPS_FILE} <<EOL
@@ -70,27 +70,27 @@ EOL
         properties:
           firehose_exporter:
             doppler:
-              url: wss://doppler.((pcf${index}_system_domain)):((pcf${index}_traffic_controller_external_port))
-              subscription_id: "((pcf${index}_metrics_environment))"
+              url: wss://doppler.((${pcfName}_system_domain)):((${pcfName}_traffic_controller_external_port))
+              subscription_id: "((${pcfName}_metrics_environment))"
               max_retry_count: 300
             uaa:
-              url: https://uaa.((pcf${index}_system_domain))
+              url: https://uaa.((${pcfName}_system_domain))
               client_id: firehose_exporter
-              client_secret: "((pcf${index}_uaa_clients_firehose_exporter_secret))"
+              client_secret: "((${pcfName}_uaa_clients_firehose_exporter_secret))"
             metrics:
-              environment: "((pcf${index}_metrics_environment))"
+              environment: "((${pcfName}_metrics_environment))"
             skip_ssl_verify: ((skip_ssl_verify))
       - name: cf_exporter
         release: prometheus
         properties:
           cf_exporter:
             cf:
-              api_url: https://api.((pcf${index}_system_domain))
+              api_url: https://api.((${pcfName}_system_domain))
               client_id: cf_exporter
-              client_secret: "((pcf${index}_uaa_clients_cf_exporter_secret))"
-              deployment_name: ((pcf${index}_metron_deployment_name))
+              client_secret: "((${pcfName}_uaa_clients_cf_exporter_secret))"
+              deployment_name: ((${pcfName}_metron_deployment_name))
             metrics:
-              environment: "((pcf${index}_metrics_environment))"
+              environment: "((${pcfName}_metrics_environment))"
             skip_ssl_verify: ((skip_ssl_verify))
 EOL
   done

--- a/init-config.sh
+++ b/init-config.sh
@@ -106,12 +106,12 @@ EOL
     #validateStringInput $firehoseExporterSecret
 
     cat >> ./${PARAM_FILE} <<EOL
-pcf${c}_metrics_environment: $pcfName
-pcf${c}_metron_deployment_name: cf
-pcf${c}_system_domain: $sysDomain
-pcf${c}_traffic_controller_external_port: 443
-pcf${c}_uaa_clients_cf_exporter_secret: $cfExporterSecret
-pcf${c}_uaa_clients_firehose_exporter_secret: $firehoseExporterSecret
+${pcfName}_metrics_environment: $pcfName
+${pcfName}_metron_deployment_name: cf
+${pcfName}_system_domain: $sysDomain
+${pcfName}_traffic_controller_external_port: 443
+${pcfName}_uaa_clients_cf_exporter_secret: $cfExporterSecret
+${pcfName}_uaa_clients_firehose_exporter_secret: $firehoseExporterSecret
 EOL
 
     cat >> ./ops/${EXPORTER_OPS_FILE} <<EOL
@@ -132,27 +132,27 @@ EOL
         properties:
           firehose_exporter:
             doppler:
-              url: wss://doppler.((pcf${c}_system_domain)):((pcf${c}_traffic_controller_external_port))
-              subscription_id: "((pcf${c}_metrics_environment))"
+              url: wss://doppler.((${pcfName}_system_domain)):((${pcfName}_traffic_controller_external_port))
+              subscription_id: "((${pcfName}_metrics_environment))"
               max_retry_count: 300
             uaa:
-              url: https://uaa.((pcf${c}_system_domain))
+              url: https://uaa.((${pcfName}_system_domain))
               client_id: firehose_exporter
-              client_secret: "((pcf${c}_uaa_clients_firehose_exporter_secret))"
+              client_secret: "((${pcfName}_uaa_clients_firehose_exporter_secret))"
             metrics:
-              environment: "((pcf${c}_metrics_environment))"
+              environment: "((${pcfName}_metrics_environment))"
             skip_ssl_verify: ((skip_ssl_verify))
       - name: cf_exporter
         release: prometheus
         properties:
           cf_exporter:
             cf:
-              api_url: https://api.((pcf${c}_system_domain))
+              api_url: https://api.((${pcfName}_system_domain))
               client_id: cf_exporter
-              client_secret: "((pcf${c}_uaa_clients_cf_exporter_secret))"
-              deployment_name: ((pcf${c}_metron_deployment_name))
+              client_secret: "((${pcfName}_uaa_clients_cf_exporter_secret))"
+              deployment_name: ((${pcfName}_metron_deployment_name))
             metrics:
-              environment: "((pcf${c}_metrics_environment))"
+              environment: "((${pcfName}_metrics_environment))"
             skip_ssl_verify: ((skip_ssl_verify))
 EOL
 
@@ -161,4 +161,3 @@ EOL
 else 
    echo -e "\nAbort. Param file: ${PARAM_FILE} and/or exporter ops file: ./ops/${EXPORTER_OPS_FILE} already exist(s)."
 fi
-


### PR DESCRIPTION
When adding environments at different times the scripts end up calling
things pcf1, even if pcf1 already exists. Using the name makes more
sense and is easier to read in the file and in credhub.

Also a quick clarification on the README that caused some confusion for
me.